### PR TITLE
Proper __ne__ comparisons

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -62,7 +62,8 @@ class Options(object):
         self.__dict__ = kw
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return type(self) is type(other) and \
+            self.__dict__ == other.__dict__
 
     def __ne__(self, other):
         return not self == other


### PR DESCRIPTION
(it's more a test of pull request function than actual contribution)

Unlike python 3, in python 2.\* non-equality comparison is not derived from equality one, thus the patch.
