### PR TITLE
Add support for argument defaults

### DIFF
--- a/language_agnostic_test/language_agnostic_tester.py
+++ b/language_agnostic_test/language_agnostic_tester.py
@@ -587,6 +587,43 @@ r"""usage: prog [-opr]
 $ prog -op
 {"-o": true, "-p": true, "-r": false}
 
+
+r"""Dictionary
+
+Usage:
+  prog [options] <word> [<language>]
+
+Arguments:
+  <word>        The word to lookup
+  <language>    The language to use [default: English]
+
+Options:
+  -h --help     Help
+  --verbose
+
+"""
+$ prog PROGRAMMING
+{"--help": false,
+ "--verbose": false,
+ "<word>": "PROGRAMMING",
+ "<language>": "English"}
+
+$ prog BONJOUR FRENCH
+{"--help": false,
+ "--verbose": false,
+ "<word>": "BONJOUR",
+ "<language>": "FRENCH"}
+
+r"""usage: prog [PATH]
+
+PATH  Directory to use [default: ./]
+
+"""
+$ prog
+{"PATH": "./"}
+
+$ prog "Some Folder"
+{"PATH": "Some Folder"}
 '''
 import sys, json
 from subprocess import Popen, PIPE, STDOUT


### PR DESCRIPTION
Argument descriptions will be recognized as any line that starts with an argument.
It will be ignored if there is not a [default: ] section in the description. Multi-line descriptions are supported.

This commit fixes issue #36. It also disables option parsing within any `usage:` section.