### PR TITLE
Allows one or more fixed arguments after a repeating argument

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -126,6 +126,8 @@ class ParrentPattern(Pattern):
 
     @property
     def flat(self):
+        for c in self.children:
+            c.parent = self
         return sum([c.flat for c in self.children], [])
 
 
@@ -226,6 +228,20 @@ class OneOrMore(ParrentPattern):
         l_ = None
         matched = True
         times = 0
+
+        subsequent_argc = 0
+        if hasattr(self, 'parent'):
+            for x in self.parent.children[self.parent.children.index(self)+1:]:
+                if not isinstance(x, Argument):
+                    break
+                subsequent_argc += 1
+
+        if subsequent_argc:
+            subsequent = l[-subsequent_argc:]
+            l = l[0:-subsequent_argc]
+        else:
+            subsequent = []
+        
         while matched:
             # could it be that something didn't match but changed l or c?
             matched, l, c = self.children[0].match(l, c)
@@ -233,8 +249,9 @@ class OneOrMore(ParrentPattern):
             if l_ == l:
                 break
             l_ = l
+
         if times >= 1:
-            return True, l, c
+            return True, l + subsequent, c
         return False, left, collected
 
 

--- a/language_agnostic_test/language_agnostic_tester.py
+++ b/language_agnostic_test/language_agnostic_tester.py
@@ -487,6 +487,16 @@ $ prog
 {"NAME": []}
 
 
+r"""usage: prog NAME... FOO
+
+"""
+$ prog foo bar baz
+{"NAME": ["foo", "bar"], "FOO":"baz"}
+
+$ prog foo bar
+{"NAME": ["foo"], "FOO":"bar"}
+
+
 r"""usage: prog (NAME | --foo NAME)
 
 --foo

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -546,3 +546,19 @@ def test_multiple_different_elements():
     assert docopt('usage: prog (go <direction> --speed=<km/h>)...',
                   'go left --speed=5  go right --speed=9') == \
             {'go': 2, '<direction>': ['left', 'right'], '--speed': ['5', '9']}
+
+
+def test_argument_can_follow_repeating_argument():
+    assert docopt('usage: prog <target>... <source>', 'foo bar baz') == \
+            {'<target>':['foo', 'bar'], '<source>': 'baz'}
+
+
+def test_several_arguments_can_follow_repeating_argument():
+    assert docopt('usage: prog <target>... <source> <flerb>', 'foo bar baz qux') == \
+            {'<target>':['foo', 'bar'], '<source>': 'baz', '<flerb>': 'qux'}
+
+
+def test_argument_can_follow_repeating_option():
+    assert docopt('usage: prog --file=<file> ... <target>', '--file=foo --file=bar outdir') == \
+            {'--file':['foo', 'bar'], '<target>': 'outdir'}
+


### PR DESCRIPTION
I was having trouble with a script that uses the "multiple sources followed by a target" scheme you see in `cp` and `mv`:

``` python
import docopt

if __name__ == "__main__":
    args = docopt.docopt("Usage: cp [-hv] <target>... <source>")
    print args
```

docopt currently just eats all arguments into `<target>`, so the script borks on usage.

This pull request implements support for looking ahead and seeing if the next object in the parent of a OneOrMany is an Argument, and tries to avoid swallowing more than necessary. The patch itself is rather hacky and not really up to snuff, particularly the bit where the parent gets assigned. I'm also not 100% sure how fix_list_arguments impacts on the ability to treat the result of parse_pattern as a full tree.

I've submitted it anyway as more of a demonstration for how I "solved" the problem in the hope that we can use it as a stepping-off point for doing it right (assuming, of course, it's agreed that docopt should support this!)
