### PR TITLE
Change `exit()` to `sys.exit()` in docopt.py

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -430,10 +430,10 @@ def formal_usage(printable_usage):
 def extras(help, version, options, doc):
     if help and any((o.name in ('-h', '--help')) and o.value for o in options):
         print(doc.strip())
-        exit()
+        sys.exit()
     if version and any(o.name == '--version' and o.value for o in options):
         print(version)
-        exit()
+        sys.exit()
 
 
 class Dict(dict):


### PR DESCRIPTION
Replace `exit()` with `sys.exit()`. Helpful when using with freeze utilities such as bb-freeze or py2exe; the normal `exit()` call causes issues in the frozen script.
