### PR TITLE
strip()ing usage message ruins ascii art

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -429,7 +429,7 @@ def formal_usage(printable_usage):
 
 def extras(help, version, options, doc):
     if help and any((o.name in ('-h', '--help')) and o.value for o in options):
-        print(doc.strip())
+        print(doc.strip("\n"))
         sys.exit()
     if version and any(o.name == '--version' and o.value for o in options):
         print(version)


### PR DESCRIPTION
Here's a victim:

``` python
"""
             __
  .--.--.--.|  |_.--.--.--.
  |  |  |  ||   _|  |  |  |
  |________||____|________|

  wondering whats worth watching?
  "what to watch" helps you decide.

Usage:
  wtw [<imdb_id_or_file_or_directory>...] [-e...] [-t...] [options]
  wtw --help | --version
...
"""
```

Here's the victims output (before patch):

```
(pip_test_env)➜  wtw  wtw -h
__
  .--.--.--.|  |_.--.--.--.
  |  |  |  ||   _|  |  |  |
  |________||____|________|

  wondering whats worth watching?
  "what to watch" helps you decide.
...
```

Here's the victims output (after patch):

```
(pip_test_env)➜  wtw  wtw -h
             __
  .--.--.--.|  |_.--.--.--.
  |  |  |  ||   _|  |  |  |
  |________||____|________|

  wondering whats worth watching?
  "what to watch" helps you decide.
...
```
