### PR TITLE
Add __version__ to module.

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -1,6 +1,7 @@
 import sys
 import re
 
+__version__ = "0.5.0"
 
 class DocoptLanguageError(Exception):
 


### PR DESCRIPTION
The `__version__` global is a common method of including a module version information. Refer to PEP 3001: http://www.python.org/dev/peps/pep-3001/#unification-of-module-metadata
