### PR TITLE
allow running the tests on python 2.5

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,8 @@
 import re
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 import pytest
 
@@ -12,7 +15,7 @@ def pytest_collect_file(path, parent):
 
 
 def parse_test(raw):
-    raw = re.sub('#.*$', '', raw, flags=re.M).strip()
+    raw = re.compile('#.*$', re.M).sub('', raw).strip()
     if raw.startswith('"""'):
         raw = raw[3:]
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,8 @@ envlist = py25, py26, py27, py30, py31, py32, pypy
 [testenv]
 commands = py.test
 deps = pytest
+
+[testenv:py25]
+commands = py.test
+deps = pytest
+     simplejson


### PR DESCRIPTION
python 2.5 doesn't have the json module, re.sub doesn't take a flags
argument.
