### PR TITLE
fix option parsing with multiple subcommands containing '[options]'

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -565,9 +565,10 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     #        a.value = same_name[0].value
     argv = parse_argv(TokenStream(argv, DocoptExit), list(options),
                       options_first)
+    pattern_options = set(pattern.flat(Option))
     for ao in pattern.flat(AnyOptions):
         doc_options = parse_defaults(doc)
-        ao.children = list(set(doc_options) - set(pattern.flat(Option)))
+        ao.children = list(set(doc_options) - pattern_options)
         #if any_options:
         #    ao.children += [Option(o.short, o.long, o.argcount)
         #                    for o in argv if type(o) is Option]

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -575,3 +575,10 @@ def test_issue_65_evaluate_argv_when_called_not_when_imported():
     assert docopt('usage: prog [-ab]') == {'-a': True, '-b': False}
     sys.argv = 'prog -b'.split()
     assert docopt('usage: prog [-ab]') == {'-a': False, '-b': True}
+
+
+def test_issue_85_any_option_multiple_subcommands():
+    docopt('usage:\n  fs good [options]\n  fs fail [options]\n\nOptions:\n  --loglevel=<loglevel>\n',
+                  'fail --loglevel 5') ==  {'--loglevel': '5',
+                                            'fail': True,
+                                            'good': False}


### PR DESCRIPTION
this is issue 85.
