### PR TITLE
added jython compiled classes to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ nosetests.xml
 
 # Sphinx
 docs/_*
+
+# jython
+*$py.class


### PR DESCRIPTION
Because I use your lib (great work btw.) as a subproject with jython it compiles $py.class java classes.
Now git starts to bother me, telling me that the subrepo is dirty.

Adding *$py.class to git ignore, which is the jython equvalient of a .pyc, solves this issue.
