### PR TITLE
changes Dict class instatiation with 'type' function

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -570,7 +570,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     extras(help, version, argv, doc)
     matched, left, collected = pattern.fix().match(argv)
     if matched and left == []:  # better error message if left?
-        r = lambda s: '{%s}'%',\n '.join('%r: %r'%i for i in sorted(s.items()))
-        Dict = type('Dict', (dict,), {'__repr__': r})
+        Dict = type('Dict', (dict,), {'__repr__': lambda s:
+                '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(s.items()))})
         return Dict((a.name, a.value) for a in (pattern.flat() + collected))
     raise DocoptExit()


### PR DESCRIPTION
Removes the five lines of code that implement the Dict class;
Instantiates the equivalent class with the Python built-in functions 'type' and 'lambda';

Only creates+instantiates Dict when needed;
Module with less 3 lines of code (yey! :+1:);

Respects the 79 character line-width "rule" from PEP8;
Respects the usage of "'" instead of "\"" for strings;
