### PR TITLE
Make sure the dict of parsed parameters is in the same order as in the usage text

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -9,6 +9,16 @@
 import sys
 import re
 
+try:
+    # The python standard library contains OrderedDict in version >= 2.7
+    from collections import OrderedDict
+except ImportError:
+    # Try substitution package for python 2.4-2.6 (https://pypi.python.org/pypi/ordereddict).
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        # Otherwise use unsorted dict
+        OrderedDict = dict
 
 __all__ = ['docopt']
 __version__ = '0.6.1'
@@ -482,7 +492,7 @@ def extras(help, version, options, doc):
         sys.exit()
 
 
-class Dict(dict):
+class Dict(OrderedDict):
     def __repr__(self):
         return '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(self.items()))
 


### PR DESCRIPTION
For example, if you define the following parameters:

```
<param1> <param2>
```

And you parse the parameters:

```
arguments = docopt(__doc__)
```

Then the arguments should be in the same order:

```
print arguments.keys()

-> [param1, param2]
```

This solution uses OrderedDict which is supported in Python 2.7 and higher. It also works with the ordereddict package for Python 2.4-2.6 (https://pypi.python.org/pypi/ordereddict/1.1).
