### PR TITLE
Format dictionary for key string eval

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -483,20 +483,6 @@ def extras(help, version, options, doc):
 
 
 class Dict(dict):
-    def __init__(self, *args, **kwargs):
-        self.__setitem__('strip_chars', kwargs['strip_chars'])
-        for (key, value) in args[0]:
-            self.__setitem__(key, value)
-
-    def __setitem__(self, key, value):
-        if super(Dict, self).has_key('strip_chars') and self['strip_chars']:
-            super(Dict, self).__setitem__(self.format_key(key), value)
-        else:
-            super(Dict, self).__setitem__(key, value)
-
-    def format_key(self, key):
-        return key.lower().translate(None, '-<>')  # Remove all POSIX special characters
-
     def __repr__(self):
         return '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(self.items()))
 
@@ -604,8 +590,9 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False, strip_c
     extras(help, version, argv, doc)
     matched, left, collected = pattern.fix().match(argv)
     if matched and left == []:  # better error message if left?
-        retdict = Dict(((a.name, a.value) for a in (pattern.flat() + collected)), strip_chars=strip_chars)
-        retdict.pop('strip_chars')
+        retdict = Dict((a.name, a.value) for a in (pattern.flat() + collected))
+        if strip_chars:
+            retdict = Dict((key.translate(None, '-<>'), value) for key, value in retdict.items())
         return retdict
     raise DocoptExit()
 


### PR DESCRIPTION
ENH: Added optional flag 'strip_chars' to remove POSIX characters '-', '<', '>' from docopt.docopt dictionary.  Operations that evaluate the key strings will not throw a syntax error and **kwargs syntax is preserved.

```python
"""
Usage:
  my_test --work <time>
  my_test --lazy

Options:
  --work boolean
"""
import docopt

def my_lazy(lazy=False, **kwargs):  # BAD: (--lazy=False, **kwargs)
    if lazy:
        print "Taking a break..."

def my_function(work=False, time, **kwargs):  # BAD: (--work=False, <time>, **kwargs)
    if work:
        for t in time:
             print "Doing some work!"
        my_lazy(**kwargs)


if name == "main":
    kwargs = docopt.docopt(doc, strip_chars=True)
    # Application-specific dispatch logic
    if kwargs['work']:
        my_function(**kwargs)
    else:
        my_lazy(**kwargs)
```
