### PR TITLE
Some minor changes to help aid in porting; mostly non-functional changes

### DIFF
--- a/test_docopt.py
+++ b/test_docopt.py
@@ -306,8 +306,6 @@ def test_pattern_either():
 
 
 def test_pattern_fix_repeating_arguments():
-    assert Option('-a').fix_repeating_arguments() == Option('-a')
-    assert Argument('N', None).fix_repeating_arguments() == Argument('N', None)
     assert Required(Argument('N'),
                     Argument('N')).fix_repeating_arguments() == \
             Required(Argument('N', []), Argument('N', []))


### PR DESCRIPTION
While preparing the C++ port, I had a few suggestions to help ease porting for other languages:
- I moved the "fix" functions in Pattern to the BranchPattern subclass. These functions do not apply to leaf nodes, and moving them down helps makes Pattern's interface clearer. This also lets us remove the "hasattr('children')" check.
- Add some **init** up-calls that were missing (some non-functional, but still should be included for correctness, in my opinion).
- Added some extra comments.
- Changed "Tokens" to not inherit from "list". The only thing that Token really needed was to be iterable, and that can be accomplished via **iter**. I'm always hesitant to subclass fundamental types, as it is to easy for others to accidentally strip it later.

I considered changing the "transform" function and remove the Either/Required parts at the end. The only caller of this function unwraps the Either and the Required and just operates on the children. In the C++ port, I made this function take a list of patterns and return a list-of-list-of-patterns, and avoided wrapping either in Either/Required classes. I'm not sure if this is helpful or not, so I didnt include it -- but I thought I'd bring it up.

I understand this patch may be controversial, but hopefully it's helpful (or at least some parts).
