### PR TITLE
[FIX] "TypeError: unsupported operand type(s) for +" when something is not str

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -26,7 +26,7 @@ class DocoptExit(SystemExit):
     usage = ''
 
     def __init__(self, message=''):
-        SystemExit.__init__(self, (message + '\n' + self.usage).strip())
+        SystemExit.__init__(self, (unicode(message) + '\n' + unicode(self.usage)).strip())
 
 
 class Pattern(object):


### PR DESCRIPTION
Got an issue on https://github.com/opdemand/deis CLI, but seems to be related to naive concatenation of parameters of  `DocoptExit.__init__()`

This should fix the issue.
