### PR TITLE
Upload a python wheel for docopt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
Configures the setup.py option `bdist_wheel` to build a universal wheel, for both python 2 & 3.

This allows for creating and uploading a python wheel to pypi. You can see more information on wheels at http://pythonwheels.com 

Wheels are a binary distribution format that require no 'building' for the user, and and additionally make caching 3rd party modules for fast installation extremely easy. In contrast to eggs, they can be installed by pip, and they also work with virtualenv. I'd love for docopt to help become an adopter of the new format!

To create one, simply have the [wheel](https://pypi.python.org/pypi/wheel) package installed from pypi and you will then have access to `python setup.py bdist_wheel` command.

If you'd like to hear any more information about them of course leave a comment and I'll be happy to answer :)
