### PR TITLE
Remove comments from usage section before parsing.

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -469,6 +469,10 @@ def parse_section(name, source):
 
 def formal_usage(section):
     _, _, section = section.partition(':')  # drop "usage:"
+
+    #Remove comments from usage section.
+    section, _num_comments = re.subn('#.+?(?=(\\n|$))', '', section)
+
     pu = section.split()
     return '( ' + ' '.join(') | (' if s == pu[0] else s for s in pu[1:]) + ' )'
 


### PR DESCRIPTION
Hi,
       I just wanted to propose a change to allow comments in the usage section.

It's pretty useful to allow a small description of the usage pattern through a comment.

Currently, if you have something like:
"""
Usage:
              program argument1                             #Comments about usage.
"""

The parser does not recognize the comment.

The regexp substitution in formal_usage will allow comments of this style to be used in the Usage section.

thanks,
-Sravan
