### PR TITLE
Improve tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,13 @@ project--it is self-contained.
 
 **docopt** is tested with Python 2.5, 2.6, 2.7, 3.2, 3.3 and PyPy.
 
+Testing
+======================================================================
+
+You can run unit tests using the command:
+
+    python setup.py test
+
 API
 ======================================================================
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,22 @@
+import sys
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
 
 from docopt import __version__
+
+
+class PyTestCommand(TestCommand):
+    """ Command to run unit py.test unit tests
+    """
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run(self):
+        import pytest
+        rcode = pytest.main(self.test_args)
+        sys.exit(rcode)
 
 
 setup(
@@ -24,4 +40,10 @@ setup(
         'Programming Language :: Python :: 3.3',
         'License :: OSI Approved :: MIT License',
     ],
+    tests_require=[
+            'pytest',
+        ],
+    cmdclass={
+            'test': PyTestCommand,
+        }
 )


### PR DESCRIPTION
This pull request improves Docopt tests. It's now possible to run tests by executing:

```
python setup.py test
```
