### PR TITLE
Mark this as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
This means that a wheel built on any platform can be used any other platform. (This is true, since docopt is pure python)
