### PR TITLE
Added only_passed argument

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -512,6 +512,10 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False,
     options_first : bool (default: False)
         Set to True to require options precede positional arguments,
         i.e. to forbid options and positional arguments intermix.
+    only_passed : bool (default: False)
+        Return only the arguments the user actually provided. This
+        can be used to update existing configurations with command
+        line arguments.
 
     Returns
     -------
@@ -578,7 +582,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False,
     extras(help, version, argv, doc)
     matched, left, collected = pattern.fix().match(argv)
     if matched and left == []:  # better error message if left?
-        if isinstance(only_passed, dict):
-            only_passed.update(Dict((a.name, a.value) for a in collected))
+        if only_passed:
+            return Dict((a.name, a.value) for a in collected)
         return Dict((a.name, a.value) for a in (pattern.flat() + collected))
     raise DocoptExit()

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -414,6 +414,9 @@ def test_docopt():
     assert a == {'-v': True, '-q': False, '-r': False, '--help': False,
                  'FILE': None, 'INPUT': None, 'OUTPUT': None}
 
+    a = docopt(doc, '-v', only_passed=True)
+    assert a == {'-v': True}
+
     with raises(DocoptExit):  # does not match
         docopt(doc, '-v input.py output.py')
 


### PR DESCRIPTION
I want to use docopt in conjunction with environment variables and config files.
So configuration options can come from different locations and i want to prioritize the options which come from docopt.

The problem is that docopt always returns all the arguments and options specified in the description, even when you did not pass them via command line.
I know that this is expected behavior.
But when you priorize docopts options most, you will automaticly overwrite all the options which came from the other locations, e.g. with default values or with None. In that case docopt will become unusable.

The solution is to offer the developer a way to just get the arguments and options which were really passed on commandline, despite all the other arguments specified in the description.

```
environ_config = os.environ()
...

file_config = ...

cli_passed_config = {}
cli_args = docopt(doc_string, version=version,
                  only_passed=cli_passed_config)

config = collections.ChainMap(
    cli_passed_config,
    environ_config,
    file_config
)
```
