### PR TITLE
Update testcases.docopt

### DIFF
--- a/testcases.docopt
+++ b/testcases.docopt
@@ -47,7 +47,7 @@ $ prog --verbose
 {"--verbose": true}
 
 $ prog --ver
-{"--verbose": true}
+"user-error"
 
 $ prog -v
 {"--verbose": true}
@@ -80,10 +80,10 @@ $ prog --path=home/
 {"--path": "home/"}
 
 $ prog --pa home/
-{"--path": "home/"}
+"user-error"
 
 $ prog --pa=home/
-{"--path": "home/"}
+"user-error"
 
 $ prog --path
 "user-error"
@@ -178,8 +178,7 @@ $ prog --ver
 "user-error"
 
 $ prog --verb
-{"--version": false,
- "--verbose": true}
+"user-error"
 
 
 r"""usage: prog [-a -r -m <msg>]
@@ -196,7 +195,7 @@ $ prog -armyourass
  "-m": "yourass"}
 
 
-r"""usage: prog [-armmsg]
+r"""usage: prog [-armMSG]
 
 options: -a        Add
          -r        Remote
@@ -669,6 +668,7 @@ $ prog -aa
 #
 
 r"""Usage: prog [options] A
+
 Options:
     -q  Be quiet
     -v  Be verbose.
@@ -712,6 +712,7 @@ $ prog
 #
 
 r"""usage: prog [options]
+
 options:
  -a        Add
  -m <msg>  Message
@@ -876,7 +877,7 @@ $ prog -pHOME
 # Issue 56: Repeated mutually exclusive args give nested lists sometimes
 #
 
-r"""Usage: foo (--xx=x|--yy=y)..."""
+r"""Usage: foo (--xx=X|--yy=Y)..."""
 $ prog --xx=1 --yy=2
 {"--xx": ["1"], "--yy": ["2"]}
 


### PR DESCRIPTION
I'm not 100% sure that all my changes are correct (especially the first few to `"user-error"`, but I couldn't find anything in the Docopt README that said names can be accessed via prefix).

Would you be open to adding tests that require more sophisticated pattern matching? e.g., `cp FILE... DIR`. I have it working in my [Rust port](https://github.com/BurntSushi/docopt.rs) along with all tests passing.
