### PR TITLE
Better error message when None is passed in as doc

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -552,6 +552,9 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     """
     argv = sys.argv[1:] if argv is None else argv
 
+    if doc is None:
+        raise DocoptLanguageError('doc is None!')
+
     usage_sections = parse_section('usage:', doc)
     if len(usage_sections) == 0:
         raise DocoptLanguageError('"usage:" (case-insensitive) not found.')

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -614,3 +614,10 @@ def test_parse_section():
 def test_issue_126_defaults_not_parsed_correctly_when_tabs():
     section = 'Options:\n\t--foo=<arg>  [default: bar]'
     assert parse_defaults(section) == [Option(None, '--foo', 1, 'bar')]
+
+
+def test_issue_133_obscure_message_on_doc_as_None():
+    # previously the error was reported from "parse_section"
+    # as "TypeError: expected string or buffer"
+    with raises(DocoptLanguageError):
+        docopt(None)


### PR DESCRIPTION
`__doc__` becomes None, when there is an import before the string, which happened for at least two users, when using the construct `from __future__ import ...`, which is also sensitive to placement within file.

Fixes #133
