### PR TITLE
detect string in a way that works with both Python 2.x and 3.x

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -13,6 +13,11 @@ import re
 __all__ = ['docopt']
 __version__ = '0.6.1'
 
+PY3 = sys.version_info[0] == 3
+if PY3:
+    string_types = str,
+else:
+    string_types = basestring,
 
 class DocoptLanguageError(Exception):
 
@@ -120,7 +125,7 @@ class LeafPattern(Pattern):
             if type(self.value) is int:
                 increment = 1
             else:
-                increment = ([match.value] if type(match.value) is str
+                increment = ([match.value] if isinstance(match.value, string_types)
                              else match.value)
             if not same_name:
                 match.value = increment


### PR DESCRIPTION
This is how the six package detects strings (see http://stackoverflow.com/a/20612311/81346)

It resolves https://github.com/docopt/docopt/issues/219
