### PR TITLE
Add option to set cmdline option's value from environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -306,6 +306,7 @@ It is necessary to list option descriptions in order to specify:
 - synonymous short and long options,
 - if an option has an argument,
 - if option's argument has a default value.
+- if option's argument can be set from environment variable.
 
 The rules are as follows:
 
@@ -342,6 +343,13 @@ The rules are as follows:
     --coefficient=K  The K coefficient [default: 2.95]
     --output=FILE    Output file [default: test.txt]
     --directory=DIR  Some directory [default: ./]
+
+- If you want to set the option's value from environment variable, put
+  it into the option-description, in form ``[envvar:
+  <environment-variabale-name>]``::
+
+    -q                Quit [envvar: DOCOPT_QUIET]
+    --output=FILE     Output file [envvar: DOCOPT_OUTPUT]
 
 - If the option is not repeatable, the value inside ``[default: ...]``
   will be interpreted as string.  If it *is* repeatable, it will be

--- a/docopt.py
+++ b/docopt.py
@@ -6,6 +6,7 @@
  * Copyright (c) 2013 Vladimir Keleshev, vladimir@keleshev.com
 
 """
+import os
 import sys
 import re
 
@@ -196,9 +197,13 @@ class Option(LeafPattern):
                 short = s
             else:
                 argcount = 1
-        if argcount:
-            matched = re.findall('\[default: (.*)\]', description, flags=re.I)
-            value = matched[0] if matched else None
+        envvar = re.findall('\[envvar: (.*?)\]', description, flags=re.I)
+        if envvar:
+            value = os.environ.get(envvar[0])
+        if argcount and not value:
+            if not value:
+                matched = re.findall('\[default: (.*?)\]', description, flags=re.I)
+                value = matched[0] if matched else None
         return class_(short, long, argcount, value)
 
     def single_match(self, left):

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -1,4 +1,6 @@
 from __future__ import with_statement
+import os
+
 from docopt import (docopt, DocoptExit, DocoptLanguageError,
                     Option, Argument, Command, OptionsShortcut,
                     Required, Optional, Either, OneOrMore,
@@ -505,6 +507,23 @@ def test_default_value_for_positional_arguments():
           """
     a = docopt(doc, '--data=this')
     assert a == {'--data': ['this']}
+
+
+def test_environment_variable_for_positional_arguments():
+    os.environ['DOCOPT_DATA'] = 'x'
+
+    doc = """Usage: prog [--data=<data>...]\n
+             Options:\n\t-d --data=<arg>    Input data [envvar: DOCOPT_DATA]
+          """
+    a = docopt(doc, '')
+    assert a == {'--data': ['x']}
+
+    # Environment variables should have priority over defaults.
+    doc = """Usage: prog [--data=<data>...]\n
+             Options:\n\t-d --data=<arg>    Input data [default: y] [envvar: DOCOPT_DATA]
+          """
+    a = docopt(doc, '')
+    assert a == {'--data': ['x']}
 
 
 #def test_parse_defaults():


### PR DESCRIPTION
Add a new token [envvar: ...] to option description that enable setting
an option value from the correspondent environment variable, which
precede default value but can be overrited by explicitly setting the
option value from command line.