### PR TITLE
Fix examples/interactive_example.py serial sub command not work bug.

### DIFF
--- a/examples/interactive_example.py
+++ b/examples/interactive_example.py
@@ -66,6 +66,7 @@ class MyInteractive (cmd.Cmd):
     @docopt_cmd
     def do_serial(self, arg):
         """Usage: serial <port> [--baud=<n>] [--timeout=<seconds>]
+
 Options:
     --baud=<n>  Baudrate [default: 9600]
         """


### PR DESCRIPTION
See issue #280 