### PR TITLE
Hide unset option

### DIFF
--- a/examples/config_file_example.py
+++ b/examples/config_file_example.py
@@ -4,6 +4,7 @@
   quick_example.py -h | --help | --version
 
 """
+from collections import ChainMap
 from docopt import docopt
 
 
@@ -50,24 +51,13 @@ def load_ini_config():
                 for key, value in config.items('default-arguments'))
 
 
-def merge(dict_1, dict_2):
-    """Merge two dictionaries.
-
-    Values that evaluate to true take priority over falsy values.
-    `dict_1` takes priority over `dict_2`.
-
-    """
-    return dict((str(key), dict_1.get(key) or dict_2.get(key))
-                for key in set(dict_2) | set(dict_1))
-
-
 if __name__ == '__main__':
     json_config = load_json_config()
     ini_config = load_ini_config()
-    arguments = docopt(__doc__, version='0.1.1rc')
+    arguments = docopt(__doc__, version='0.1.1rc', hide_unset=True)
 
     # Arguments take priority over INI, INI takes priority over JSON:
-    result = merge(arguments, merge(ini_config, json_config))
+    result = ChainMap(arguments, ini_config, json_config)
 
     from pprint import pprint
     print('\nJSON config:')


### PR DESCRIPTION
The *hide_unset* option provides a way to filter out all arguments that are not given by the user.
This is particularly useful when using docopt while other sources of arguments are expected, as in the *config_file_example.py* example.

This PR contains:
- implementation of the option (in *docopt.py*)
- rewriting of the *config_file_example.py* file, using the *hide_unset* option
