### PR TITLE
Fix `setup.py test`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ class PyTestCommand(TestCommand):
         self.test_args = []
         self.test_suite = True
 
-    def run(self):
+    def run_tests(self):
         import pytest
         rcode = pytest.main(self.test_args)
         sys.exit(rcode)


### PR DESCRIPTION
- otherwise ignores `tests_require` from `setup.py`
- could call `super` or just stick it [where it belongs](https://bitbucket.org/pypa/setuptools/src/0d80c1398b1901def27014ec91230103d0830188/setuptools/command/test.py?at=default&fileviewer=file-view-default#test.py-161)
