### PR TITLE
Updated versions of Python used in testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,3 @@
 language: python
 install: pip install tox --use-mirrors
 script: tox
-
-# Disable SSL (Python 2.5 does not have "ssl" module).
-env: PIP_INSECURE=true

--- a/README.rst
+++ b/README.rst
@@ -87,12 +87,12 @@ Installation
 
 Use `pip <http://pip-installer.org>`_ or easy_install::
 
-    pip install docopt==0.6.1
+    pip install docopt==0.6.2
 
 Alternatively, you can just drop ``docopt.py`` file into your
 project--it is self-contained.
 
-**docopt** is tested with Python 2.5, 2.6, 2.7, 3.2, 3.3 and PyPy.
+**docopt** is tested with Python 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy.
 
 Testing
 ======================================================================
@@ -438,8 +438,9 @@ first release with stable API will be 1.0.0 (soon).  Until then, you
 are encouraged to specify explicitly the version in your dependency
 tools, e.g.::
 
-    pip install docopt==0.6.1
+    pip install docopt==0.6.2
 
+- 0.6.2 Bugfix release.
 - 0.6.1 Bugfix release.
 - 0.6.0 ``options_first`` parameter.
   **Breaking changes**: Corrected ``[options]`` meaning.

--- a/docopt.py
+++ b/docopt.py
@@ -11,7 +11,7 @@ import re
 
 
 __all__ = ['docopt']
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 
 class DocoptLanguageError(Exception):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py25, py26, py27, py32, py33, pypy
+envlist = py26, py27, py33, py34, py35, pypy
 
 [testenv]
 commands = py.test


### PR DESCRIPTION
The tests have been failing at [TravisCI.org](https://travis-ci.org/docopt/docopt/) since they stopped supporting Python 2.5. This removes that from the tox config and adds Python 3.4 and 3.5. Also references to `docopt==0.6.1` were replaced with the current v0.6.2.

[Here is an example](https://travis-ci.org/docopt/docopt/builds/27479747) of how docopt master is currently failing tests.