### PR TITLE
An option description can be located after a new line.

### DIFF
--- a/testcases.docopt
+++ b/testcases.docopt
@@ -955,3 +955,23 @@ other options:
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+
+# An option description can be located after a new line.
+r"""usage: prog [options]
+
+options:
+  --foo, -f
+      Description on a new line.
+  --bar, -b
+      Description on a new line.
+"""
+
+$ prog --foo
+{"--foo": true, "--bar": false}
+$ prog --f
+{"--foo": true, "--bar": false}
+$ prog --bar
+{"--foo": false, "--bar": true}
+$ prog -b
+{"--foo": false, "--bar": true}


### PR DESCRIPTION
Sometimes if an option is too long, it looks better when its description starts on a new line.

This behaviour is supported by the current implementation (intentionally or unintentionally), the commit secures this fact, so it can be safely ported into re-implementations (I am especially interested in C++ version).