### PR TITLE
Add argument name to `Options` class and make it accessible from the argument dict

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -179,27 +179,30 @@ class Command(Argument):
 
 class Option(LeafPattern):
 
-    def __init__(self, short=None, long=None, argcount=0, value=False):
+    def __init__(self, short=None, long=None, argcount=0, value=False, atype=None):
         assert argcount in (0, 1)
         self.short, self.long, self.argcount = short, long, argcount
         self.value = None if value is False and argcount else value
 
     @classmethod
     def parse(class_, option_description):
-        short, long, argcount, value = None, None, 0, False
+        short, long, argcount, value, atype = None, None, 0, False, None
         options, _, description = option_description.strip().partition('  ')
-        options = options.replace(',', ' ').replace('=', ' ')
+        options = options.replace(',', ' ').replace('=', ' =')
         for s in options.split():
             if s.startswith('--'):
                 long = s
             elif s.startswith('-'):
                 short = s
+            elif s.startswith('='):
+                atype = s[1:]
+                arcount = 1
             else:
                 argcount = 1
         if argcount:
             matched = re.findall('\[default: (.*)\]', description, flags=re.I)
             value = matched[0] if matched else None
-        return class_(short, long, argcount, value)
+        return class_(short, long, argcount, value, atype)
 
     def single_match(self, left):
         for n, pattern in enumerate(left):
@@ -212,8 +215,8 @@ class Option(LeafPattern):
         return self.long or self.short
 
     def __repr__(self):
-        return 'Option(%r, %r, %r, %r)' % (self.short, self.long,
-                                           self.argcount, self.value)
+        return 'Option(%r, %r, %r, %r, %r)' % (self.short, self.long,
+                                self.argcount, self.value, self.atype)
 
 
 class Required(BranchPattern):

--- a/docopt.py
+++ b/docopt.py
@@ -183,6 +183,7 @@ class Option(LeafPattern):
         assert argcount in (0, 1)
         self.short, self.long, self.argcount = short, long, argcount
         self.value = None if value is False and argcount else value
+        self.atype = atype
 
     @classmethod
     def parse(class_, option_description):
@@ -196,7 +197,7 @@ class Option(LeafPattern):
                 short = s
             elif s.startswith('='):
                 atype = s[1:]
-                arcount = 1
+                argcount = 1
             else:
                 argcount = 1
         if argcount:
@@ -486,6 +487,10 @@ def extras(help, version, options, doc):
 
 
 class Dict(dict):
+    def __init__(self, options, *args):
+        self.options = options
+        dict.__init__(self, *args)
+
     def __repr__(self):
         return '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(self.items()))
 
@@ -580,5 +585,5 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     extras(help, version, argv, doc)
     matched, left, collected = pattern.fix().match(argv)
     if matched and left == []:  # better error message if left?
-        return Dict((a.name, a.value) for a in (pattern.flat() + collected))
+        return Dict(options, ((a.name, a.value) for a in (pattern.flat() + collected)))
     raise DocoptExit()


### PR DESCRIPTION
Consider the option strings
```
-o --option=<int>         An Option
-a --another=<float>   Another Option
```

For post-processing of command line arguments it is sometimes useful to have the argument type available (meaning `<int>` or `<float>` in the example above).

E.g. for things like:

```
    args = ldocopt.docopt(a,['.'])
    for k, v in args.iteritems():
        atype = [t.atype for t in args.options if t.long == k]
        atype = atype[0] if atype else None
        if atype == '<int>':
            args[k] = int(v)
        elif atype == '<float>':
            args[k] = float(v)     
```