### PR TITLE
Add a test case for default values containing `]`

### DIFF
--- a/testcases.docopt
+++ b/testcases.docopt
@@ -955,3 +955,16 @@ other options:
 """
 $ prog --baz --egg
 {"--foo": false, "--baz": true, "--bar": false, "--egg": true, "--spam": false}
+
+#
+# JSON-Lists as default values
+#
+
+r"""Usage: prog [-l <JSON list>]
+
+Options:
+  -l, --list <JSON list>  A JSON list [default: []]
+
+"""
+$prog
+{"--list": "[]"}


### PR DESCRIPTION
I found this while trying to write a parsing-method for [docopt/docopt.cpp](https://github.com/docopt/docopt.cpp) that doesn't rely on regular expressions:
If one does not use a greedy match like `\[default: (.*)\]` for the default parsing, default values containing `]` characters will yield wrong results (think of an empty JSON-list: `[default: [] ]`).