### PR TITLE
Update classifiers to match README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,15 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Topic :: Utilities',
-        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'License :: OSI Approved :: MIT License',
     ],
     tests_require=[


### PR DESCRIPTION
The README says:

> **docopt** is tested with Python 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy.