### PR TITLE
Fix travis again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
-sudo: false
 language: python
-python: 3.5
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-matrix:
-  include:
-    - env: TOX_ENV=py36
-      python: "3.6"
-install: pip install tox
-script: tox -e $TOX_ENV
+cache: pip
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: pip install tox tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 language: python
 python: 3.5
 env:
-  - TOX_ENV=py26
   - TOX_ENV=py27
-  - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=py35
-  - TOX_ENV=pypy
 matrix:
   include:
     - env: TOX_ENV=py36

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,14 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy
+envlist = py27, py34, py35, py36
+
+[travis]
+python =
+  2.7: py27
+  3.4: py34
+  3.5: py35
+  3.6: py36
 
 [testenv]
 commands = py.test
@@ -14,8 +21,3 @@ deps = pytest
 commands = py.test
            py.test --doctest-modules docopt.py
 deps = pytest
-
-[testenv:py25]
-commands = py.test
-deps = pytest
-       simplejson


### PR DESCRIPTION
The Travis CI configuration for docopt got rusty to the point where fixes by @graingert in #381 still wouldn't work. This narrows test coverage in CI down to the main current versions recommended by @hugovk : 2.7, 3.4, 3.5, and 3.6. It also refactors the .travis.yml and tox.ini files similarly to the [django-wiki](https://github.com/django-wiki/django-wiki) project as suggested by @benjaoming. Suggestions welcome!
  