### PR TITLE
Update pypi classifiers and README to match python test versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Use `pip <http://pip-installer.org>`_ or easy_install::
 Alternatively, you can just drop ``docopt.py`` file into your
 project--it is self-contained.
 
-**docopt** is tested with Python 2.6, 2.7, 3.3, 3.4, 3.5 and PyPy.
+**docopt** is tested with Python 2.7, 3.4, 3.5, and 3.6.
 
 Testing
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Topic :: Utilities',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
     tests_require=[


### PR DESCRIPTION
After #401 was merged, this updates things to correctly reference the versions `docopt` is tested with. cc: @hugovk.

Closes #394.