### PR TITLE
 Allow negative floats and integers fix #397

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -434,13 +434,19 @@ def parse_argv(tokens, options, options_first=False):
         argv ::= [ long | shorts | argument ]* [ '--' [ argument ]* ] ;
 
     """
+    def isanumber(x):
+        try:
+            float(x)
+            return True
+        except ValueError:
+            return False
     parsed = []
     while tokens.current() is not None:
         if tokens.current() == '--':
             return parsed + [Argument(None, v) for v in tokens]
         elif tokens.current().startswith('--'):
             parsed += parse_long(tokens, options)
-        elif tokens.current().startswith('-') and tokens.current() != '-':
+        elif tokens.current().startswith('-') and tokens.current() != '-' and not isanumber(tokens.current()):
             parsed += parse_shorts(tokens, options)
         elif options_first:
             return parsed + [Argument(None, v) for v in tokens]

--- a/testcases.docopt
+++ b/testcases.docopt
@@ -337,6 +337,15 @@ $ prog 10
 $ prog 10 20
 "user-error"
 
+$ prog -1
+{"<arg>": "-1"}
+
+$ prog -10
+{"<arg>": "-10"}
+
+$ prog -3.14159265
+{"<arg>": "-3.14159265"}
+
 $ prog
 "user-error"
 


### PR DESCRIPTION
THIS IS MY FIRST COMMIT EVER {help please}
```
Usage:
      mystuff <x> <y>
now accepts mystuff -22 -3.141592
```
One consequence is that it bans the use of :
```
Usage:
        mystuff -1
Options:
        -1      This is totally a valid option but what is the use case ?
```
I added some tests for it