### PR TITLE
Add a minimal pyproject.toml following pep-0518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools', 'wheel']
+


### PR DESCRIPTION
This allows docopt to be installed via pip if setuptools
is not yet installed in the environment. Without this, projects depending on docopt would have to make sure that setuptools is already installed before trying to install dependencies, even if these projects do not use setuptools themselves.