### PR TITLE
Corrected a small typo in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ API
 - ``options_first``, by default ``False``.  If set to ``True`` will
   disallow mixing options and positional argument.  I.e. after first
   positional argument, all arguments will be interpreted as positional
-  even if the look like options.  This can be used for strict
+  even if they look like options.  This can be used for strict
   compatibility with POSIX, or if you want to dispatch your arguments
   to other programs.
 


### PR DESCRIPTION
Replaced "the" with "they" at line 168 of the README.rst