### PR TITLE
Add type feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ docs/_*
 
 # jython
 *$py.class
+
+.idea/

--- a/docopt.py
+++ b/docopt.py
@@ -186,13 +186,18 @@ class Command(Argument):
 
 class Option(LeafPattern):
 
-    def __init__(self, short=None, long=None, argcount=0, value=False, type_value=None, choices_value=None):
+    def __init__(self, short=None, long=None, argcount=0, value=False, type_value=None, choices_value=None, types=None):
         assert argcount in (0, 1)
         self.short, self.long, self.argcount = short, long, argcount
 
         if type_value is not None:
-            assert type_value in TYPE_MAP or type_value == 'str'
-            self.type_class = TYPE_MAP[type_value]
+            if types is not None:
+                type_map = dict(**TYPE_MAP, **types)
+            else:
+                type_map = TYPE_MAP
+            assert type_value in type_map
+
+            self.type_class = type_map[type_value]
         else:
             self.type_class = None
         if choices_value is not None:
@@ -205,9 +210,10 @@ class Option(LeafPattern):
 
         self.type_value = type_value
         self.choices_value = choices_value
+        self.types = types
 
     @classmethod
-    def parse(class_, option_description):
+    def parse(class_, option_description, types=None):
         short, long, argcount, value = None, None, 0, False
         options, _, description = option_description.strip().partition('  ')
         options = options.replace(',', ' ').replace('=', ' ')
@@ -228,7 +234,7 @@ class Option(LeafPattern):
         choices_matched = re.findall('\[choices: (.*?)\]', description, flags=re.I)
         choices_value = choices_matched[0] if choices_matched else None
 
-        return class_(short, long, argcount, value, type_value, choices_value)
+        return class_(short, long, argcount, value, type_value, choices_value, types)
 
     def single_match(self, left):
         for n, pattern in enumerate(left):
@@ -355,7 +361,7 @@ def parse_long(tokens, options):
             o = Option(None, long, argcount, value if argcount else True)
     else:
         o = Option(similar[0].short, similar[0].long,
-                   similar[0].argcount, similar[0].value, similar[0].type_value, similar[0].choices_value)
+                   similar[0].argcount, similar[0].value, similar[0].type_value, similar[0].choices_value, similar[0].types)
         if o.argcount == 0:
             if value is not None:
                 raise tokens.error('%s must not have an argument' % o.long)
@@ -488,14 +494,14 @@ def parse_argv(tokens, options, options_first=False):
     return parsed
 
 
-def parse_defaults(doc):
+def parse_defaults(doc, types=None):
     defaults = []
     for s in parse_section('options:', doc):
         # FIXME corner case "bla: options: --foo"
         _, _, s = s.partition(':')  # get rid of "options:"
         split = re.split('\n[ \t]*(-\S+?)', '\n' + s)[1:]
         split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])]
-        options = [Option.parse(s) for s in split if s.startswith('-')]
+        options = [Option.parse(s, types) for s in split if s.startswith('-')]
         defaults += options
     return defaults
 
@@ -526,7 +532,7 @@ class Dict(dict):
         return '{%s}' % ',\n '.join('%r: %r' % i for i in sorted(self.items()))
 
 
-def docopt(doc, argv=None, help=True, version=None, options_first=False):
+def docopt(doc, argv=None, help=True, version=None, options_first=False, types=None):
     """Parse `argv` based on command-line interface described in `doc`.
 
     `docopt` creates your command-line interface based on its
@@ -550,6 +556,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
     options_first : bool (default: False)
         Set to True to require options precede positional arguments,
         i.e. to forbid options and positional arguments intermix.
+    types : dict
 
     Returns
     -------
@@ -598,7 +605,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):
         raise DocoptLanguageError('More than one "usage:" (case-insensitive).')
     DocoptExit.usage = usage_sections[0]
 
-    options = parse_defaults(doc)
+    options = parse_defaults(doc, types)
     pattern = parse_pattern(formal_usage(DocoptExit.usage), options)
     # [default] syntax for argument is disabled
     #for a in pattern.flat(Argument):

--- a/docopt.py
+++ b/docopt.py
@@ -13,6 +13,13 @@ import re
 __all__ = ['docopt']
 __version__ = '0.6.2'
 
+TYPE_MAP = {
+    'int': int,
+    'float': float,
+    'complex': complex,
+    'str': str,
+}
+
 
 class DocoptLanguageError(Exception):
 
@@ -184,9 +191,8 @@ class Option(LeafPattern):
         self.short, self.long, self.argcount = short, long, argcount
 
         if type_value is not None:
-            type_dict = {'int': int, 'float': float, }
-            assert type_value in type_dict or type_value == 'str'
-            self.type_class = type_dict[type_value] if type_value in type_dict else str
+            assert type_value in TYPE_MAP or type_value == 'str'
+            self.type_class = TYPE_MAP[type_value]
         else:
             self.type_class = None
         if choices_value is not None:

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -649,12 +649,12 @@ def test_user_defined_types():
 
 
 def test_choices():
-    doc = """Usage: prog --data=<data>\n
+    doc = """Usage: prog [--data=<data>]\n
                  Options:\n\t-d --data=<data>    Input data [choices: A B C]
               """
     a = docopt(doc, '--data=A')
     assert a == {'--data': 'A'}
-    doc = """Usage: prog --data=<data>\n
+    doc = """Usage: prog [--data=<data>]\n
                      Options:\n\t-d --data=<data>    Input data [choices: A B C] [default: C]
                   """
     a = docopt(doc, '')

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -636,10 +636,14 @@ def test_user_defined_types():
     doc = """Usage: prog --data=<data>\n
                      Options:\n\t-d --data=<data>    Input data [type: Foo]
                   """
+
     class Foo:
         def __init__(self, number):
             self.number = int(number)
             assert self.number < 10
+
+        def __eq__(self, other):
+            return self.number == other.number
 
     a = docopt(doc, '--data=1', types={'Foo': Foo})
     assert a == {'--data': Foo('1')}

--- a/test_docopt.py
+++ b/test_docopt.py
@@ -620,12 +620,12 @@ def test_issue_126_defaults_not_parsed_correctly_when_tabs():
 
 
 def test_types():
-    doc = """Usage: prog --data=<data>\n
+    doc = """Usage: prog [--data=<data>]\n
                  Options:\n\t-d --data=<data>    Input data [type: float]
               """
     a = docopt(doc, '--data=0.1')
     assert a == {'--data': 0.1}
-    doc = """Usage: prog --data=<data>\n
+    doc = """Usage: prog [--data=<data>]\n
              Options:\n\t-d --data=<data>    Input data [default: 10] [type: int]
           """
     a = docopt(doc, '')


### PR DESCRIPTION
This PR implements the core functionality of this project, which is type validation feature.
You can now add `[type: int]` or `[choices: A B C]` to your docstring and the argument will be validated accordingly.

Public accessibility, documentation, etc. will be addressed in the later PRs.