### PR TITLE
Expose DocoptExit exception in the __all__

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -10,7 +10,7 @@ import sys
 import re
 
 
-__all__ = ['docopt']
+__all__ = ['docopt', 'DocoptExit']
 __version__ = '0.6.2'
 
 


### PR DESCRIPTION
Let users to raise DocoptExit from their code to indicate an error in the arguments.
This is often required when arguments need to go through additional validation