### PR TITLE
[RFC] Add sketch of specifying option groups

### DIFF
--- a/examples/option_groups.py
+++ b/examples/option_groups.py
@@ -1,0 +1,33 @@
+"""Example of program with many options groups using docopt.
+
+Usage:
+  option_groups.py [--port=<port>] [cert_opts] [options] serve <fsroot>
+  option_groups.py [--port=<port>] [cert_opts] [options] upload <host> <file>...
+  option_groups.py [options] changes <local_dir>
+  option_groups.py (-h | --help)
+  option_groups.py --version
+
+Arguments:
+  <fsroot>                  local directory to serve
+  <file>                    file(s) to upload
+  <local_dir>               directory to check for local changes
+
+Certificate options [cert_opts]:
+  --certfile=<certfile>     X509 certificate
+  --keyfile=<keyfile>       key for certificate
+
+General options [options]:
+  -v --verbose              print status messages
+
+Other options:
+  -h --help                 show this help message and exit
+  --version                 show version and exit
+  -p <port> --port=<port>   port to use
+
+"""
+from docopt import docopt
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='1.0.0')
+    print(arguments)


### PR DESCRIPTION
This proposal explores the idea of grouping related options to allow the CLI designer to more precisely determine which options make sense with given commands. This is particularly relevant for mid-to-large CLI utilities, such as `rsync` and `git`, for example.

#### Commit

The POSIX Utility argument syntax specifies a single OPTIONS section.
If there are options make sense only with some set of operands
(commands), then it currently seems to be required to list these for
each operand.

This example explores the potential of define multiple option groups,
which would hopefully help both the command line interface designer and
user to specify and select the correct options for each operand.

Signed-off-by: Eero Aaltonen <eero.aaltonen@vaisala.com>

#### Additional Notes:

* It seems this principle has once been implemented and rejected in #313 (with a different syntax however).
* This proposal was partially inspired by https://github.com/docopt/docopt/issues/374#issuecomment-296577685

This would change the current behavior of
"[options] can be expanded to any options listed in the "Options:" section"

to
"any option group listed in help message can be expanded to the options in that group". Of course the details of what is considered an option group would have to hashed out.