### PR TITLE
Resolve invalid escape sequence warnings

### DIFF
--- a/docopt.py
+++ b/docopt.py
@@ -157,8 +157,8 @@ class Argument(LeafPattern):
 
     @classmethod
     def parse(class_, source):
-        name = re.findall('(<\S*?>)', source)[0]
-        value = re.findall('\[default: (.*)\]', source, flags=re.I)
+        name = re.findall(r'(<\S*?>)', source)[0]
+        value = re.findall(r'\[default: (.*)\]', source, flags=re.I)
         return class_(name, value[0] if value else None)
 
 
@@ -197,7 +197,7 @@ class Option(LeafPattern):
             else:
                 argcount = 1
         if argcount:
-            matched = re.findall('\[default: (.*)\]', description, flags=re.I)
+            matched = re.findall(r'\[default: (.*)\]', description, flags=re.I)
             value = matched[0] if matched else None
         return class_(short, long, argcount, value)
 
@@ -288,7 +288,7 @@ class Tokens(list):
     @staticmethod
     def from_pattern(source):
         source = re.sub(r'([\[\]\(\)\|]|\.\.\.)', r' \1 ', source)
-        source = [s for s in re.split('\s+|(\S*<.*?>)', source) if s]
+        source = [s for s in re.split(r'\s+|(\S*<.*?>)', source) if s]
         return Tokens(source, error=DocoptLanguageError)
 
     def move(self):
@@ -454,7 +454,7 @@ def parse_defaults(doc):
     for s in parse_section('options:', doc):
         # FIXME corner case "bla: options: --foo"
         _, _, s = s.partition(':')  # get rid of "options:"
-        split = re.split('\n[ \t]*(-\S+?)', '\n' + s)[1:]
+        split = re.split(r'\n[ \t]*(-\S+?)', r'\n' + s)[1:]
         split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])]
         options = [Option.parse(s) for s in split if s.startswith('-')]
         defaults += options
@@ -462,7 +462,7 @@ def parse_defaults(doc):
 
 
 def parse_section(name, source):
-    pattern = re.compile('^([^\n]*' + name + '[^\n]*\n?(?:[ \t].*?(?:\n|$))*)',
+    pattern = re.compile(r'^([^\n]*' + name + r'[^\n]*\n?(?:[ \t].*?(?:\n|$))*)',
                          re.IGNORECASE | re.MULTILINE)
     return [s.strip() for s in pattern.findall(source)]
 


### PR DESCRIPTION
Simple change to prefix any regular expression matching strings with `r` to ensure they are used as raw strings and do not throw an invalid escape sequence warning:
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/11192738/208687545-b899c48f-5735-4f0e-97ca-33bb6b4e73cb.png">
