### PR TITLE
Bob schumaker/python312

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import re
 try:
     import json
@@ -11,7 +12,7 @@ import docopt
 
 def pytest_collect_file(path, parent):
     if path.ext == ".docopt" and path.basename.startswith("test"):
-        return DocoptTestFile(path, parent)
+        return DocoptTestFile.from_parent(parent, path=Path(path))
 
 
 def parse_test(raw):

--- a/docopt.py
+++ b/docopt.py
@@ -157,8 +157,8 @@ class Argument(LeafPattern):
 
     @classmethod
     def parse(class_, source):
-        name = re.findall('(<\S*?>)', source)[0]
-        value = re.findall('\[default: (.*)\]', source, flags=re.I)
+        name = re.findall(r'(<\S*?>)', source)[0]
+        value = re.findall(r'\[default: (.*)\]', source, flags=re.I)
         return class_(name, value[0] if value else None)
 
 
@@ -197,7 +197,7 @@ class Option(LeafPattern):
             else:
                 argcount = 1
         if argcount:
-            matched = re.findall('\[default: (.*)\]', description, flags=re.I)
+            matched = re.findall(r'\[default: (.*)\]', description, flags=re.I)
             value = matched[0] if matched else None
         return class_(short, long, argcount, value)
 
@@ -288,7 +288,7 @@ class Tokens(list):
     @staticmethod
     def from_pattern(source):
         source = re.sub(r'([\[\]\(\)\|]|\.\.\.)', r' \1 ', source)
-        source = [s for s in re.split('\s+|(\S*<.*?>)', source) if s]
+        source = [s for s in re.split(r'\s+|(\S*<.*?>)', source) if s]
         return Tokens(source, error=DocoptLanguageError)
 
     def move(self):
@@ -454,7 +454,7 @@ def parse_defaults(doc):
     for s in parse_section('options:', doc):
         # FIXME corner case "bla: options: --foo"
         _, _, s = s.partition(':')  # get rid of "options:"
-        split = re.split('\n[ \t]*(-\S+?)', '\n' + s)[1:]
+        split = re.split(r'\n[ \t]*(-\S+?)', '\n' + s)[1:]
         split = [s1 + s2 for s1, s2 in zip(split[::2], split[1::2])]
         options = [Option.parse(s) for s in split if s.startswith('-')]
         defaults += options


### PR DESCRIPTION
Fix the newly introduced SyntaxWarning for invalid escape sequences in Python 3.12 by using raw strings everywhere.

Additionally, upgrade to the latest pytest syntax for FSCollector so the test still run.